### PR TITLE
A better way to ensure pipeline have closed successfully, fixes #43. 

### DIFF
--- a/pycoral/pipeline/pipelined_model_runner.py
+++ b/pycoral/pipeline/pipelined_model_runner.py
@@ -80,9 +80,15 @@ class PipelinedModelRunner:
   def __del__(self):
     if self._runner:
       # Push empty request to stop the pipeline in case user forgot.
-      self.push({})
-      num_unconsumed = 0
+      try:
+        print("Push empty request to stop the pipeline...")
+        self.push({})
+      except RuntimeError:
+        print("The pipeline has already been closed successfully.")
+        return
+
       # Release any unconsumed tensors if any.
+      num_unconsumed = 0
       while self.pop():
         num_unconsumed += 1
       if num_unconsumed:


### PR DESCRIPTION
This fixes #43, reporting pipeline example [model_pipelining_classify_image.py](https://github.com/google-coral/pycoral/blob/master/examples/model_pipelining_classify_image.py) results in a Runtime Error. 
Part of the error logs comes from [libcoral](https://github.com/google-coral/libcoral), I submitted [another PR](https://github.com/google-coral/libcoral/pull/25) for that.

The error is caused by [***PipelinedModelRunner***'s  \_\_del\_\_() function](https://github.com/google-coral/pycoral/blob/master/pycoral/pipeline/pipelined_model_runner.py), pushing an empty request to ensure pipeline closes. 
The example code have passed an empty request earlier during execution, and already closed the pipeline. Passing the empty request again will result in Runtime Error.

I wrapped the action of pushing an empty request inside an try statement, while retaining the function to release unconsumed tensors. This is the following result of the pipeline example after modification:
```bash
$ python3 model_pipelining_classify_image.py --models test_data/pipeline/inception_v3_299_quant_segment_%d_of_2_edgetpu.tflite --labels test_data/imagenet_labels.txt --input test_data/parrot.jpg
Using devices:  ['usb:0', 'usb:1']
Using models:  ['test_data/pipeline/inception_v3_299_quant_segment_0_of_2_edgetpu.tflite', 'test_data/pipeline/inception_v3_299_quant_segment_1_of_2_edgetpu.tflite']
/home/pi/Downloads/tests/test2_mod_py/model_pipelining_classify_image.py:130: DeprecationWarning: ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
  Image.open(args.input).convert('RGB').resize(size, Image.ANTIALIAS))
WARNING: Logging before InitGoogleLogging() is written to STDERR
I20220606 19:23:16.864081  3949 pipelined_model_runner.cc:175] Thread: 2881299520 receives empty request
I20220606 19:23:16.864403  3949 pipelined_model_runner.cc:248] Thread: 2881299520 is shutting down the pipeline...
I20220606 19:23:17.116384  3949 pipelined_model_runner.cc:258] Thread: 2881299520 Pipeline is off.
I20220606 19:23:17.116871  3950 pipelined_model_runner.cc:210] Queue is empty and `StopWaiters()` is called.
-------RESULTS--------
macaw: 0.99609
Average inference time (over 5 iterations): 55.4ms
Push empty request to stop the pipeline...
I20220606 19:23:17.117740  3928 pipelined_model_runner.cc:175] Thread: 3069839744 receives empty request
E20220606 19:23:17.118194  3928 pipelined_model_runner.cc:243] Thread: 3069839744 Pipeline was turned off before.
The pipeline has already been closed successfully.
E20220606 19:23:17.118814  3928 pipelined_model_runner.cc:243] Thread: 3069839744 Pipeline was turned off before.
E20220606 19:23:17.118907  3928 pipelined_model_runner.cc:150] Failed to shutdown status: INTERNAL: Pipeline was turned off before.
```

There are two additional error logs after the line "The pipeline has already been closed successfully.", and the error logs are caused by [pipelined_model_runner.cc](https://github.com/google-coral/libcoral/blob/master/coral/pipeline/pipelined_model_runner.cc) in [libcoral](https://github.com/google-coral/libcoral), which is another problem to be fixed in that repo.