### PR TITLE
Fix an IndexError edge case

### DIFF
--- a/pycoral/adapters/detect.py
+++ b/pycoral/adapters/detect.py
@@ -234,4 +234,4 @@ def get_objects(interpreter,
         bbox=BBox(xmin=xmin, ymin=ymin, xmax=xmax,
                   ymax=ymax).scale(sx, sy).map(int))
 
-  return [make(i) for i in range(count) if scores[i] >= score_threshold]
+  return [make(i) for i in range(len(scores)) if scores[i] >= score_threshold]


### PR DESCRIPTION
There was an index error that occurs sometimes when running a custom edge tpu model. Disagreement between count and len(scores). I've confirmed that this resolves the error